### PR TITLE
.BRA Update: Alpha, anim speed & output

### DIFF
--- a/KyleHyde/Formats/LastWindow/LWBRF.cs
+++ b/KyleHyde/Formats/LastWindow/LWBRF.cs
@@ -163,29 +163,19 @@ namespace KyleHyde.Formats.LastWindow
                                     alpha = (byte)((lookup >> 5) * 36);
                                     lookup = (byte)(lookup & 0x1F);
 
-                                    if (alpha == 72)
-                                    {
-                                        alpha = 73;
-                                    }
-                                    if (alpha == 108)
-                                    {
-                                        alpha = 109;
-                                    }
-                                    if (alpha == 144)
-                                    {
-                                        alpha = 146;
-                                    }
-                                    if (alpha == 180)
-                                    {
-                                        alpha = 182;
-                                    }
-                                    if (alpha == 216)
-                                    {
-                                        alpha = 219;
-                                    }
-                                    if (alpha == 252)
-                                    {
-                                        alpha = 255;
+                                    switch(alpha) {
+                                        case 72:
+                                        case 108:
+                                            alpha += 1;
+                                            break;
+                                        case 144:
+                                        case 180:
+                                            alpha += 2;
+                                            break;
+                                        case 216:
+                                        case 252:
+                                            alpha += 3;
+                                            break;
                                     }
                                 }
 

--- a/KyleHyde/Formats/LastWindow/LWBRF.cs
+++ b/KyleHyde/Formats/LastWindow/LWBRF.cs
@@ -1,4 +1,4 @@
-﻿using GameTools;
+using GameTools;
 using System;
 using System.Drawing;
 
@@ -162,6 +162,31 @@ namespace KyleHyde.Formats.LastWindow
                                 {
                                     alpha = (byte)((lookup >> 5) * 36);
                                     lookup = (byte)(lookup & 0x1F);
+
+                                    if (alpha == 72)
+                                    {
+                                        alpha = 73;
+                                    }
+                                    if (alpha == 108)
+                                    {
+                                        alpha = 109;
+                                    }
+                                    if (alpha == 144)
+                                    {
+                                        alpha = 146;
+                                    }
+                                    if (alpha == 180)
+                                    {
+                                        alpha = 182;
+                                    }
+                                    if (alpha == 216)
+                                    {
+                                        alpha = 219;
+                                    }
+                                    if (alpha == 252)
+                                    {
+                                        alpha = 255;
+                                    }
                                 }
 
                                 Color c = Color.FromArgb(alpha, palette[lookup]);

--- a/KyleHyde/WindowImageAnimated.xaml.cs
+++ b/KyleHyde/WindowImageAnimated.xaml.cs
@@ -1,10 +1,20 @@
-﻿using System;
-using System.Diagnostics;
+using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
 
 namespace KyleHyde {
     /// <summary>
@@ -12,7 +22,6 @@ namespace KyleHyde {
     /// </summary>
     public partial class WindowImageAnimated : Window {
 
-        private string name;
         private Bitmap[] bmps;
         private BitmapImage[] bitmapImages;
         private int indexLast;
@@ -22,17 +31,27 @@ namespace KyleHyde {
             InitializeComponent();
         }
 
-        public WindowImageAnimated(Bitmap[] bmps, string name) {
+        public WindowImageAnimated(Bitmap[] bmps) {
             InitializeComponent();
 
-            Title += " - " + name;
-            this.name = name;
             this.bmps = bmps;
             bitmapImages = new BitmapImage[bmps.Length];
             indexLast = 0;
 
-            for(int i = 0; i < bmps.Length; i++) {
-                using (MemoryStream stream = new MemoryStream()) {
+            // Create the output folder if it does not exist
+            string outputFolderPath = "output";
+            if (!Directory.Exists(outputFolderPath))
+            {
+                Directory.CreateDirectory(outputFolderPath);
+            }
+
+            for (int i = 0; i < bmps.Length; i++)
+            {
+                string folderName = "output";
+                string fileName = System.IO.Path.Combine(folderName, $"frame_{i}.png");
+                Directory.CreateDirectory(folderName);
+
+                using (FileStream stream = File.Create(fileName)) {
                     bmps[i].Save(stream, ImageFormat.Png);
                     stream.Position = 0;
 
@@ -47,7 +66,7 @@ namespace KyleHyde {
 
             dispatcherTimer = new System.Windows.Threading.DispatcherTimer();
             dispatcherTimer.Tick += dispatcherTimer_Tick;
-            dispatcherTimer.Interval = new TimeSpan(0, 0, 0, 0, 100);
+            dispatcherTimer.Interval = new TimeSpan(0, 0, 0, 0, 150);
             dispatcherTimer.Start();
         }
 
@@ -55,16 +74,6 @@ namespace KyleHyde {
             if (indexLast >= bitmapImages.Length)
                 indexLast = 0;
             imageBox.Source = bitmapImages[indexLast++];
-        }
-
-        private void btnSaveFrames_Click(object sender, RoutedEventArgs e) {
-            Directory.CreateDirectory(@".\Export");
-            for (int i = 0; i < bmps.Length; i++) {
-                string outfile = @".\Export\" + name + "_" + i + ".png";
-                bmps[i].Save(outfile);
-                if(i == 0)
-                    Process.Start("explorer.exe", "/select, \"" + outfile + "\"");
-            }
         }
     }
 }

--- a/KyleHyde/WindowImageAnimated.xaml.cs
+++ b/KyleHyde/WindowImageAnimated.xaml.cs
@@ -1,20 +1,10 @@
 using System;
-using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace KyleHyde {
     /// <summary>
@@ -22,6 +12,7 @@ namespace KyleHyde {
     /// </summary>
     public partial class WindowImageAnimated : Window {
 
+        private string name;
         private Bitmap[] bmps;
         private BitmapImage[] bitmapImages;
         private int indexLast;
@@ -31,27 +22,17 @@ namespace KyleHyde {
             InitializeComponent();
         }
 
-        public WindowImageAnimated(Bitmap[] bmps) {
+        public WindowImageAnimated(Bitmap[] bmps, string name) {
             InitializeComponent();
 
+            Title += " - " + name;
+            this.name = name;
             this.bmps = bmps;
             bitmapImages = new BitmapImage[bmps.Length];
             indexLast = 0;
 
-            // Create the output folder if it does not exist
-            string outputFolderPath = "output";
-            if (!Directory.Exists(outputFolderPath))
-            {
-                Directory.CreateDirectory(outputFolderPath);
-            }
-
-            for (int i = 0; i < bmps.Length; i++)
-            {
-                string folderName = "output";
-                string fileName = System.IO.Path.Combine(folderName, $"frame_{i}.png");
-                Directory.CreateDirectory(folderName);
-
-                using (FileStream stream = File.Create(fileName)) {
+            for (int i = 0; i < bmps.Length; i++) {
+                using (MemoryStream stream = new MemoryStream()) {
                     bmps[i].Save(stream, ImageFormat.Png);
                     stream.Position = 0;
 
@@ -74,6 +55,16 @@ namespace KyleHyde {
             if (indexLast >= bitmapImages.Length)
                 indexLast = 0;
             imageBox.Source = bitmapImages[indexLast++];
+        }
+
+        private void btnSaveFrames_Click(object sender, RoutedEventArgs e) {
+            Directory.CreateDirectory(@".\Export");
+            for (int i = 0; i < bmps.Length; i++) {
+                string outfile = @".\Export\" + name + "_" + i + ".png";
+                bmps[i].Save(outfile);
+                if (i == 0)
+                    Process.Start("explorer.exe", "/select, \"" + outfile + "\"");
+            }
         }
     }
 }


### PR DESCRIPTION
Thanks for the github! Yes, I'm Adrot from our Youtube talks. I have asked around for some modifications to output the .BRA animations and I've got some good help. The changes do the following:
-The Animation viewer has the correct speed (150 instead of 100)
-Will automatically output the opened .BRA animation as PNG frames in a folder where the Debug/Released binaries are, called ''output''. (Should probably had rather made a button for that, but I have no idea how...). To note, putting another BRA in the program to view will override previous outputted frames in the folder, except those with a higher number than the frame numbers of the new animation.
-Will round up Alpha values, as they were multiples of 36. This made the sprites look semi transparent.

The only thing missing now is rounding up the RGB values, as the grays are slightly different from the accurate values. To note for the future the requirement I was told, ''there needs to be an additional set of code to multiply the RGB colors accordingly. Since 248's the limit for those, you'd have to add 1 for after each group of 16''. The change would probably need to be done in the LWBRF file.

I am a complete 0 at knowing C#, so my quest continues, but we are close. 5+ years I waited for this moment... Exciting times!